### PR TITLE
Bind to 127.0.0.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ These setup instructions wrap around the existing code from Peacock, and to simp
 ## ./node/bin/node: No such file or directory
 This indicates there was some issue downloading NodeJS. This can be fixed yourself by either installing node yourself through your package manager of choice or by downloading the zip and moving it to where `start.sh` lives and rename the folder to `node` (such that `node/bin/node` should return), but this may also indicate something worth filing an issue for.
 
-## [Error] Failed to use the server on 0.0.0.0:3000!
+## [Error] Failed to use the server on 127.0.0.1:3000!
 As the subsequent lines suggest, this error means that Peacock is already running somewhere else. `pkill node` should kill everything, but you should first verify with `ps aux | grep node` that the only thing you'll kill is the Peacock process (you should have output similar to the below)
 
 ```

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Change these if you want to different settings for the server
+node_host=127.0.0.1
+node_port=3000
+
 # Setup the path to include local node
 PATH=$PWD/node/bin:$PATH
 
@@ -98,6 +102,6 @@ fi
 
 info_message "Starting Peacock"
 cd Peacock
-PORT=3000 node chunk0.js
+PORT=$node_port HOST=$node_host node chunk0.js
 
 trap popd EXIT


### PR DESCRIPTION
Hi, I noticed that the Peacock server by defaults binds on 0.0.0.0 which seems like a security risk. 
I added a node_port and node_host variable in start.sh which by default is 127.0.0.1 for node_host (since I think most people use Peacock on localhost). 

Feel free to close if this is invalid.